### PR TITLE
[Update] - libopae selection when building iopipes designs

### DIFF
--- a/oneapi-samples/io_streaming_multi_pipes/src/CMakeLists.txt
+++ b/oneapi-samples/io_streaming_multi_pipes/src/CMakeLists.txt
@@ -109,7 +109,10 @@ set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAG
 # See C++SYCL_FPGA/GettingStarted/fast_recompile for details.
 target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/linux64/lib/libintel_opae_mmd.so)
 target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/linux64/lib/libMPF.so)
-target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so)
-target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so)
-
+if(EXISTS "$ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so")
+    target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so)
+endif()
+if(EXISTS "$ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so")
+    target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so)
+endif()
 

--- a/oneapi-samples/io_streaming_one_pipe/src/CMakeLists.txt
+++ b/oneapi-samples/io_streaming_one_pipe/src/CMakeLists.txt
@@ -109,6 +109,9 @@ set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAG
 # See C++SYCL_FPGA/GettingStarted/fast_recompile for details.
 target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/linux64/lib/libintel_opae_mmd.so)
 target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/linux64/lib/libMPF.so)
-target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so)
-target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so)
-
+if(EXISTS "$ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so")
+    target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/opae/install/lib64/libopae-c.so)
+endif()
+if(EXISTS "$ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so")
+    target_link_libraries(${FPGA_TARGET} $ENV{OFS_ASP_ROOT}/build/json-c/install/lib64/libjson-c.so)
+endif()


### PR DESCRIPTION
### Description
If using a network version of OPAE you might not have built opae-sdk locally (as part of the ASP). This change will use the local version of libopae if it exists, otherwise it will look to the PATH by default.

### Tests run:
Compiled iopipes design using the opae network resource.