### PR TITLE
[Fix] Point dma example sources.txt to correct sw path

### DIFF
--- a/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/sources.txt
+++ b/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/sources.txt
@@ -12,4 +12,4 @@ dma_axi_mm_mux.sv
 dma_ddr_selector.sv
 
 # Pointer to software:
-# sw:../../sw/dma.cpp
+# sw:../../sw/dma


### PR DESCRIPTION
### Description
This annotation is used by `tutorial/build/Makefile` to add symlink pointing where the output binary is written.

### Collateral (docs, reports, design examples, case IDs):


### Tests added:


### Tests run:
