### PR TITLE
[Fix] Update hello_mem_afu.json to remove uclk settings

### DIFF
--- a/tutorial/afu_types/01_pim_ifc/local_memory/hw/rtl/hello_mem_afu.json
+++ b/tutorial/afu_types/01_pim_ifc/local_memory/hw/rtl/hello_mem_afu.json
@@ -2,8 +2,6 @@
    "version": 1,
    "afu-image": {
       "power": 0,
-      "clock-frequency-high": "auto",
-      "clock-frequency-low": "auto",
       "afu-top-interface":
          {
             "class": "ofs_plat_afu"


### PR DESCRIPTION
### Description
*Describe the issue, update, change or fix and **why***

Removing user clock settings from .json file.   hello_mem_afu doesn't use uclk and the setting was causing loading failure on F2000x-PL, whose based FIM doesn't support uclks.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
