### PR TITLE
[Fix] Fix comparison to uninitialized variable

### DIFF
--- a/tutorial/afu_types/01_pim_ifc/dma/sw/dma.c
+++ b/tutorial/afu_types/01_pim_ifc/dma/sw/dma.c
@@ -299,7 +299,7 @@ int run_basic_ddr_dma_test(fpga_handle accel_handle, int transfer_size, bool ver
   if (s_is_ase_sim)
     assert(transfer_size <= TEST_BUFFER_SIZE_ASE);
   else
-    assert(test_buffer_size <= TEST_BUFFER_SIZE_HW);
+    assert(transfer_size <= TEST_BUFFER_SIZE_HW);
   
   test_buffer_size = transfer_size;
 


### PR DESCRIPTION
### Description
`test_buffer_size` was uninitialized before being used in an assertion. This fix changes the assertion to compare against transfer_size, making it more consistent with the previous assertion and fixing the outstanding Coverity issue.

