### PR TITLE
added transfer len truncation for different source/dest ar/aw.len sizes

### DIFF
--- a/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_pkg.sv
+++ b/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_pkg.sv
@@ -98,7 +98,7 @@ package dma_pkg;
     localparam DEST_ADDR_W = SRC_ADDR_W;
     localparam LENGTH_W = 20;
     localparam AXI_MM_DATA_W = 512;
-    localparam AXI_LEN_W = 8;
+    localparam AXI_LEN_W = 8; // n6001: 8; d5005: 5
     localparam AXI_MM_DATA_W_BYTES = AXI_MM_DATA_W / 8;
     localparam DDR_DATA_W = AXI_MM_DATA_W;
     localparam HOST_DATA_W = AXI_MM_DATA_W;

--- a/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_read_engine.sv
+++ b/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_read_engine.sv
@@ -148,7 +148,8 @@ module dma_read_engine #(
             next[SEND_RD_REQ_BIT]: begin
                src_mem.arvalid    <= 1'b1;
                src_mem.ar.addr    <= state[IDLE_BIT] ? descriptor.src_addr : src_mem.ar.addr;
-               src_mem.ar.len     <= ((rd_req_cnt+1) < num_rd_reqs) ? MAX_AXI_LEN : (descriptor.length[AXI_LEN_W-1:0]-1);
+               src_mem.ar.len[AXI_LEN_W-1:0]     <= ((rd_req_cnt+1) < num_rd_reqs) ? MAX_AXI_LEN : (descriptor.length[AXI_LEN_W-1:0]-1);
+               //src_mem.ar.len     <= ((rd_req_cnt+1) < num_rd_reqs) ? MAX_AXI_LEN : (descriptor.length[AXI_LEN_W-1:0]-1);
                src_mem.ar.burst   <= get_burst(descriptor.descriptor_control.mode);
                src_mem.ar.size    <= src_mem.ADDR_BYTE_IDX_WIDTH; // 111 indicates 128bytes per spec
             end

--- a/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_read_engine.sv
+++ b/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_read_engine.sv
@@ -149,7 +149,6 @@ module dma_read_engine #(
                src_mem.arvalid    <= 1'b1;
                src_mem.ar.addr    <= state[IDLE_BIT] ? descriptor.src_addr : src_mem.ar.addr;
                src_mem.ar.len[AXI_LEN_W-1:0]     <= ((rd_req_cnt+1) < num_rd_reqs) ? MAX_AXI_LEN : (descriptor.length[AXI_LEN_W-1:0]-1);
-               //src_mem.ar.len     <= ((rd_req_cnt+1) < num_rd_reqs) ? MAX_AXI_LEN : (descriptor.length[AXI_LEN_W-1:0]-1);
                src_mem.ar.burst   <= get_burst(descriptor.descriptor_control.mode);
                src_mem.ar.size    <= src_mem.ADDR_BYTE_IDX_WIDTH; // 111 indicates 128bytes per spec
             end

--- a/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_write_engine.sv
+++ b/tutorial/afu_types/01_pim_ifc/dma/hw/rtl/dma_write_engine.sv
@@ -176,7 +176,7 @@ module dma_write_engine #(
                dest_mem.aw.burst <= get_burst(descriptor.descriptor_control.mode);
                dest_mem.aw.size  <= axi_size;
                dest_mem.aw.addr  <= state[IDLE_BIT] ? descriptor.dest_addr :dest_mem.aw.addr;
-               dest_mem.aw.len   <= (state[IDLE_BIT] & ((desc_length_minus_one)>MAX_AXI_LEN)) ? MAX_AXI_LEN : 
+               dest_mem.aw.len[AXI_LEN_W-1:0]   <= (state[IDLE_BIT] & ((desc_length_minus_one)>MAX_AXI_LEN)) ? MAX_AXI_LEN : 
                                     (state[RD_FIFO_WR_DEST_BIT] & need_more_wlast)            ? MAX_AXI_LEN :
                                     (state[FIFO_EMPTY_BIT] & need_more_wlast)                 ? MAX_AXI_LEN :
                                                                                                 descriptor.length[AXI_LEN_W-1:0]-1; 


### PR DESCRIPTION
*[Fix]- Bug Fix*

------------- *Keep everything below this line* -------------------------

### Description
d5005 memory AXI bus has ar/aw.len = 5 while the host channel has ar/aw.len = 8. Original implementation assumed values were the same - this fix specifies the range that can be set when there is subtraction underflow in assigning len.

### Tests run:
Simulated n6001 (2k, 4k, 16k, 64k, 2M transfers) 
Simulated d5005 (2k, 4k, 16k, 64k)