### PR TITLE
FIx: added parameter PG_NUM_LINKS to match latest afu_main

### DIFF
--- a/tutorial/afu_types/02_hybrid/hello_world/hw/rtl/port_afu_instances.sv
+++ b/tutorial/afu_types/02_hybrid/hello_world/hw/rtl/port_afu_instances.sv
@@ -33,6 +33,7 @@
 
 module port_afu_instances
 #(
+   parameter PG_NUM_LINKS    = 1,
    parameter PG_NUM_PORTS    = 1,
    // PF/VF to which each port is mapped
    parameter pcie_ss_hdr_pkg::ReqHdr_pf_vf_info_t[PG_NUM_PORTS-1:0] PORT_PF_VF_INFO =

--- a/tutorial/afu_types/02_hybrid/local_memory/hw/rtl/port_afu_instances.sv
+++ b/tutorial/afu_types/02_hybrid/local_memory/hw/rtl/port_afu_instances.sv
@@ -33,6 +33,7 @@
 
 module port_afu_instances
 #(
+   parameter PG_NUM_LINKS    = 1,
    parameter PG_NUM_PORTS    = 1,
    // PF/VF to which each port is mapped
    parameter pcie_ss_hdr_pkg::ReqHdr_pf_vf_info_t[PG_NUM_PORTS-1:0] PORT_PF_VF_INFO =

--- a/tutorial/afu_types/03_afu_main/hello_world/hw/rtl/port_afu_instances.sv
+++ b/tutorial/afu_types/03_afu_main/hello_world/hw/rtl/port_afu_instances.sv
@@ -33,6 +33,7 @@
 
 module port_afu_instances
 #(
+   parameter PG_NUM_LINKS    = 1,
    parameter PG_NUM_PORTS    = 1,
    // PF/VF to which each port is mapped
    parameter pcie_ss_hdr_pkg::ReqHdr_pf_vf_info_t[PG_NUM_PORTS-1:0] PORT_PF_VF_INFO =


### PR DESCRIPTION
### Description
Fix for compile issue where the pr_afu_instances is missing the PG_NUM_LINKS parameter which is required in the latest afu_main files. The parameter is not used in the file.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:
built the 3 failing AFUs

### Tests run:
